### PR TITLE
ElevenLabs Text to Speech, audio_generator is outdated, I changed to updated docs

### DIFF
--- a/src/ai_companion/modules/speech/text_to_speech.py
+++ b/src/ai_companion/modules/speech/text_to_speech.py
@@ -50,13 +50,14 @@ class TextToSpeech:
             raise ValueError("Input text exceeds maximum length of 5000 characters")
 
         try:
-            audio_generator = self.client.generate(
+            audio_generator = self.client.text_to_speech.convert(
+                voice_id=settings.ELEVENLABS_VOICE_ID,
                 text=text,
-                voice=Voice(
-                    voice_id=settings.ELEVENLABS_VOICE_ID,
-                    settings=VoiceSettings(stability=0.5, similarity_boost=0.5),
-                ),
-                model=settings.TTS_MODEL_NAME,
+                model_id=settings.TTS_MODEL_NAME,
+                voice_settings= VoiceSettings(
+                    stability=0.5,
+                    similarity_boost=0.5
+                )
             )
 
             # Convert generator to bytes


### PR DESCRIPTION
# OLD METHOS NOW API HAS CHANGED
             audio_generator = self.client.generate(
                  text=text,
                 voice=Voice(
                 voice_id=settings.ELEVENLABS_VOICE_ID,
                 settings=VoiceSettings(stability=0.5, similarity_boost=0.5),
            ),
            model=settings.TTS_MODEL_NAME,
             )
.generate() is no longer supported

# New Method Added
audio_generator = self.client.text_to_speech.convert(
                voice_id=settings.ELEVENLABS_VOICE_ID,
                text=text,
                model_id=settings.TTS_MODEL_NAME,
                voice_settings = VoiceSettings(
                    stability=0.5,
                    similarity_boost=0.5
                )
            )