### PR TITLE
Add platform-specific PyTorch and NumPy dependencies for Intel Mac compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,12 @@ dependencies = [
     "aiosqlite>=0.20.0",
     "qdrant-client>=1.12.1",
     "sentence-transformers>=3.3.1",
+    # Platform-specific PyTorch and NumPy versions
+    # Intel Macs need older versions due to wheel compatibility
+    "torch>=2.0.0,<2.3.0; platform_machine == 'x86_64' and sys_platform == 'darwin'",
+    "torch>=2.0.0; platform_machine != 'x86_64' or sys_platform != 'darwin'",
+    "numpy>=1.24.0,<2.0.0; platform_machine == 'x86_64' and sys_platform == 'darwin'",
+    "numpy>=1.24.0; platform_machine != 'x86_64' or sys_platform != 'darwin'",
 ]
 
 [tool.ruff]


### PR DESCRIPTION
## Problem
Intel Mac users (x86_64) encounter installation errors because PyTorch 2.3.0+ no longer provides wheels for macosx x86_64 platforms. The latest PyTorch versions only support Apple Silicon (ARM) Macs, Linux, and Windows.

Error message:
`error: Distribution torch==2.5.1 @ registry+https://pypi.org/simple can't be installed because it doesn't have a source distribution or wheel for the current platform
hint: You're on macOS (macosx_15_0_x86_64), but torch (v2.5.1) only has wheels for: manylinux1_x86_64, manylinux2014_aarch64, macosx_11_0_arm64, win_amd64`

## Solution
This PR adds platform-specific dependencies using Python environment markers in pyproject.toml:

- Intel Macs (x86_64 + darwin): Install PyTorch 2.2.x and NumPy 1.x (latest compatible versions)
- All other platforms (ARM Macs, Linux, Windows): Install latest PyTorch 2.x+ and NumPy 2.x+

## Changes
- pyproject.toml: Added 6 lines with conditional dependencies using platform_machine and sys_platform markers

Note: uv.lock is not included in this PR to keep it reviewable. Maintainers can regenerate it by running `uv sync`.

## Benefits
- Automatic platform detection (no manual intervention required)
- Intel Mac users can install without errors  
- ARM Mac users continue to get the latest versions
- Maintains compatibility across all platforms
- No breaking changes for existing users

## Testing
Tested on macOS 15.0 (Intel x86_64) with PyTorch 2.2.2 and NumPy 1.26.4.
ARM Mac testing would be appreciated.

This ensures all course participants can set up the project successfully, regardless of their Mac architecture.