### PR TITLE
fix: replace HumanMessage with AIMessage for scenario_message in image_node

### DIFF
--- a/src/ai_companion/graph/nodes.py
+++ b/src/ai_companion/graph/nodes.py
@@ -64,7 +64,7 @@ async def image_node(state: AICompanionState, config: RunnableConfig):
     await text_to_image_module.generate_image(scenario.image_prompt, img_path)
 
     # Inject the image prompt information as an AI message
-    scenario_message = HumanMessage(content=f"<image attached by Ava generated from prompt: {scenario.image_prompt}>")
+    scenario_message = AIMessage(content=f"<image attached by Ava generated from prompt: {scenario.image_prompt}>")
     updated_messages = state["messages"] + [scenario_message]
 
     response = await chain.ainvoke(


### PR DESCRIPTION
The image node was incorrectly injecting the scenario_message as a HumanMessage.

This PR updates it to AIMessage, which matches the intended behaviour as mentioned in the comment above it in line 66.