### PR TITLE
Fix: remove double AIMessage wrapping in conversation_node

### DIFF
--- a/src/ai_companion/graph/nodes.py
+++ b/src/ai_companion/graph/nodes.py
@@ -48,7 +48,7 @@ async def conversation_node(state: AICompanionState, config: RunnableConfig):
         },
         config,
     )
-    return {"messages": AIMessage(content=response)}
+    return {"messages": response}
 
 
 async def image_node(state: AICompanionState, config: RunnableConfig):


### PR DESCRIPTION
### Problem
The `conversation_node` function in `nodes.py` was double-wrapping the LLM response, causing Pydantic validation errors. The chain's `ainvoke()` already returns an `AIMessage object`, but it was being wrapped again with `AIMessage(content=response)`.

### Error message
```
content.list[union[str,dict[any,any]]].0.str Input should be a valid string [type=string_type, input_value=('content', 'Hello! How can I help?'), input_type=tuple]
```
### Solution 
Return the response directly from `chain.ainvoke()` without wrapping it in another `AIMessage`.

### Benefits
- Fixes Pydantic validation errors in LangGraph
- Proper message handling in the state graph
- Streaming works correctly in Chainlit interface

### Testing
- Tested with Chainlit interface at `http://localhost:8000`
- Verified streaming responses work without errors




