### PR TITLE
Stop logging WhatsApp response payloads

### DIFF
--- a/src/ai_companion/interfaces/whatsapp/whatsapp_response.py
+++ b/src/ai_companion/interfaces/whatsapp/whatsapp_response.py
@@ -188,9 +188,6 @@ async def send_response(
             "text": {"body": response_text},
         }
 
-    print(headers)
-    print(json_data)
-
     async with httpx.AsyncClient() as client:
         response = await client.post(
             f"https://graph.facebook.com/v21.0/{WHATSAPP_PHONE_NUMBER_ID}/messages",
@@ -198,6 +195,7 @@ async def send_response(
             json=json_data,
         )
 
+    logger.info("WhatsApp %s response sent with status %s", message_type, response.status_code)
     return response.status_code == 200
 
 

--- a/tests/test_whatsapp_logging.py
+++ b/tests/test_whatsapp_logging.py
@@ -1,0 +1,24 @@
+import ast
+import unittest
+from pathlib import Path
+
+
+class WhatsAppLoggingTests(unittest.TestCase):
+    def test_send_response_does_not_print_secrets_or_payloads(self):
+        source = Path("src/ai_companion/interfaces/whatsapp/whatsapp_response.py").read_text()
+        module = ast.parse(source)
+        send_response = next(
+            node for node in module.body if isinstance(node, ast.AsyncFunctionDef) and node.name == "send_response"
+        )
+
+        print_calls = [
+            node
+            for node in ast.walk(send_response)
+            if isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id == "print"
+        ]
+
+        self.assertEqual(print_calls, [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Remove debug prints that logged WhatsApp request headers and response payloads
- Add safe status-only logging after the WhatsApp send attempt
- Add a static regression test to keep `send_response` free of `print` calls

## Validation
- uv run python tests/test_whatsapp_logging.py
- uvx ruff check src/ai_companion/interfaces/whatsapp/whatsapp_response.py tests/test_whatsapp_logging.py
- uvx ruff format --check src/ai_companion/interfaces/whatsapp/whatsapp_response.py tests/test_whatsapp_logging.py
- git diff --cached --check

## Secret check
- Scanned changed files and staged diff for common token patterns. No secrets found.