### PR TITLE
fix: refresh provider defaults and setup notes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,13 @@ TOGETHER_API_KEY=""
 QDRANT_URL=""
 QDRANT_API_KEY=""
 
+TEXT_MODEL_NAME="llama-3.3-70b-versatile"
+SMALL_TEXT_MODEL_NAME="llama-3.1-8b-instant"
+STT_MODEL_NAME="whisper-large-v3-turbo"
+TTS_MODEL_NAME="eleven_flash_v2_5"
+TTI_MODEL_NAME="black-forest-labs/FLUX.1-schnell-Free"
+ITT_MODEL_NAME="meta-llama/llama-4-scout-17b-16e-instruct"
+
 WHATSAPP_PHONE_NUMBER_ID = ""
 WHATSAPP_TOKEN = ""
 WHATSAPP_VERIFY_TOKEN = ""

--- a/README.md
+++ b/README.md
@@ -142,9 +142,9 @@ And if you're feeling extra brave, there's also a 2+ hour video course where we 
 
 ## How much is this going to cost me?
 
-The awesome thing about this project is **you can run it on your own computer for free!**
+The awesome thing about this project is **you can run it on your own computer without cloud hosting costs!**
 
-The **free tiers** from Groq, ElevenLabs, Qdrant Cloud, and Together AI are more than enough to get you going.
+Groq, ElevenLabs, and Qdrant Cloud offer starter-friendly plans that are enough to get you going locally. Together AI is still used for image generation, but it now requires a positive prepaid credit balance before API calls will run.
 
 If you want to try it out on Google Cloud Run, you can get a free account and get $300 in free credits. Even if you've already used up your free credits, Cloud Run is super cheap - so it will take just a buck or two for your experiments.
 
@@ -159,7 +159,7 @@ If you want to try it out on Google Cloud Run, you can get a free account and ge
   </tr>
   <tr>
     <td><img src="img/groq_logo.png" width="100" alt="Groq Logo"/></td>
-    <td>Powering the project with Llama 3.3, Llama 3.2 Vision, and Whisper. Groq models are awesome (and fast!!)</td>
+    <td>Powering the project with Llama 3.3, Llama 4 Scout, and Whisper. Groq models are awesome (and fast!!)</td>
   </tr>
   <tr>
     <td><img src="img/qdrant_logo.png" width="100" alt="Qdrant Logo"/></td>

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -57,6 +57,13 @@ TOGETHER_API_KEY=""
 QDRANT_URL=""
 QDRANT_API_KEY=""
 
+TEXT_MODEL_NAME="llama-3.3-70b-versatile"
+SMALL_TEXT_MODEL_NAME="llama-3.1-8b-instant"
+STT_MODEL_NAME="whisper-large-v3-turbo"
+TTS_MODEL_NAME="eleven_flash_v2_5"
+TTI_MODEL_NAME="black-forest-labs/FLUX.1-schnell-Free"
+ITT_MODEL_NAME="meta-llama/llama-4-scout-17b-16e-instruct"
+
 WHATSAPP_PHONE_NUMBER_ID = ""
 WHATSAPP_TOKEN = ""
 WHATSAPP_VERIFY_TOKEN = ""
@@ -83,7 +90,7 @@ As for the voice ID, you can check the available voices and select the one you p
 
 ### Together AI
 
-Log in to [Together AI](https://www.together.ai/) and, inside your account settings, create the API key.
+Log in to [Together AI](https://www.together.ai/) and, inside your account settings, create the API key. Together AI currently requires a positive prepaid credit balance before API calls will run, so add the minimum credit in Billing after creating the key.
 
 ![alt text](img/together_api_key.png)
 

--- a/src/ai_companion/settings.py
+++ b/src/ai_companion/settings.py
@@ -15,11 +15,11 @@ class Settings(BaseSettings):
     QDRANT_HOST: str | None = None
 
     TEXT_MODEL_NAME: str = "llama-3.3-70b-versatile"
-    SMALL_TEXT_MODEL_NAME: str = "gemma2-9b-it"
+    SMALL_TEXT_MODEL_NAME: str = "llama-3.1-8b-instant"
     STT_MODEL_NAME: str = "whisper-large-v3-turbo"
     TTS_MODEL_NAME: str = "eleven_flash_v2_5"
     TTI_MODEL_NAME: str = "black-forest-labs/FLUX.1-schnell-Free"
-    ITT_MODEL_NAME: str = "llama-3.2-90b-vision-preview"
+    ITT_MODEL_NAME: str = "meta-llama/llama-4-scout-17b-16e-instruct"
 
     MEMORY_TOP_K: int = 3
     ROUTER_MESSAGES_TO_ANALYZE: int = 3


### PR DESCRIPTION
## Summary
- update Ava's small Groq model default to `llama-3.1-8b-instant`
- update the Groq vision default to `meta-llama/llama-4-scout-17b-16e-instruct`
- expose the model defaults in `.env.example` so users can override them without editing Python
- clarify that Together AI still powers image generation, but now requires a positive prepaid credit balance before API calls run

## Why
This keeps the course architecture the same while reducing first-run failures from deprecated Groq model IDs and avoiding confusion around Together AI setup costs.

Refs #40.

## Validation
- `uv run --no-sync ruff check src/ai_companion/settings.py`
- `uv run --no-sync ruff format --check src/ai_companion/settings.py`
- `uv run --no-sync python -m compileall src`
- `PYTHONPATH=src` settings smoke check with dummy provider env values, confirmed:
  - `SMALL_TEXT_MODEL_NAME=llama-3.1-8b-instant`
  - `ITT_MODEL_NAME=meta-llama/llama-4-scout-17b-16e-instruct`

## Notes
I intentionally left `uv.lock` unchanged. On current `main`, `uv lock --check` reports that the existing lockfile needs to be updated, and full `ruff check src` reports import-order issues in untouched modules. I kept this PR scoped to provider defaults and setup notes so it stays easy to review.